### PR TITLE
Use the latest version of the NRSC5 API

### DIFF
--- a/nrsc5_gui.py
+++ b/nrsc5_gui.py
@@ -393,8 +393,9 @@ class NRSC5GUI(object):
 
     def play(self):
         self.radio = nrsc5.NRSC5(lambda type, evt: self.callback(type, evt))
-        self.radio.open(int(self.spin_rtl.get_value()), int(self.spin_ppm.get_value()))
+        self.radio.open(int(self.spin_rtl.get_value()))
         self.radio.set_auto_gain(self.cb_auto_gain.get_active())
+        self.radio.set_freq_correction(int(self.spin_ppm.get_value()))
 
         # set gain if auto gain is not selected
         if not self.cb_auto_gain.get_active():


### PR DESCRIPTION
The nrsc5 project recently made an API change:

https://github.com/theori-io/nrsc5/commit/80d165b457f401c39eb1d569624e0f8ce2f98c36

Namely, the `nrsc5_open` function no longer takes a `ppm` argument, and instead the frequency correction is set in `nrsc5_set_freq_correction`. I pulled in the latest version of nrsc5.py, and updated nrsc5_gui.py to set the frequency correction the new way.